### PR TITLE
Supply `AWS::StackId` as `identity` field in user data

### DIFF
--- a/flight-compute/8-node.json
+++ b/flight-compute/8-node.json
@@ -161,16 +161,16 @@
     },
     "Mappings": {
         "AWSRegionArch2AMI" : {
-            "us-east-1"      : { "HVM64" : "ami-621bf00f" },
-            "us-west-2"      : { "HVM64" : "ami-3d86795d" },
-            "us-west-1"      : { "HVM64" : "ami-d5a9d1b5" },
-            "eu-west-1"      : { "HVM64" : "ami-73c55200" },
-            "ap-southeast-1" : { "HVM64" : "ami-05429466" },
-            "ap-northeast-1" : { "HVM64" : "ami-59668738" },
-            "ap-southeast-2" : { "HVM64" : "ami-4d06292e" },
-            "sa-east-1"      : { "HVM64" : "ami-6f68e003" },
+            "us-east-1"      : { "HVM64" : "PENDING" },
+            "us-west-2"      : { "HVM64" : "PENDING" },
+            "us-west-1"      : { "HVM64" : "PENDING" },
+            "eu-west-1"      : { "HVM64" : "ami-c81e89bb" },
+            "ap-southeast-1" : { "HVM64" : "PENDING" },
+            "ap-northeast-1" : { "HVM64" : "PENDING" },
+            "ap-southeast-2" : { "HVM64" : "PENDING" },
+            "sa-east-1"      : { "HVM64" : "PENDING" },
             "cn-north-1"     : { "HVM64" : "NOT_SUPPORTED" },
-            "eu-central-1"   : { "HVM64" : "ami-d4cb27bb" }
+            "eu-central-1"   : { "HVM64" : "PENDING" }
         },
         "AWSRegionFeatures" : {
             "us-east-1"      : { "Lambda" : "true" },
@@ -726,10 +726,7 @@
                                         }, {
                                             "Fn::Join": [
                                                 "",
-                                                [
-                                                    "      uuid: '", { "Ref": "AWS::StackId" }, "'\n",
-                                                    "      token: '", { "Ref": "AWS::StackId" }, "'\n"
-                                                ]
+                                                ["      identity: '", { "Ref": "AWS::StackId" }, "'\n"]
                                             ]
                                         }
                                     ]
@@ -841,10 +838,7 @@
                                         }, {
                                             "Fn::Join": [
                                                 "",
-                                                [
-                                                    "      uuid: '", { "Ref": "AWS::StackId" }, "'\n",
-                                                    "      token: '", { "Ref": "AWS::StackId" }, "'\n"
-                                                ]
+                                                ["      identity: '", { "Ref": "AWS::StackId" }, "'\n"]
                                             ]
                                         }
                                     ]


### PR DESCRIPTION
In combination with Clusterware 1.5.2, this will fix #56.
